### PR TITLE
Updated "runc" variable in opensuse_leap15/42.3

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -132,7 +132,7 @@ opensuse_leap42.3: $(addsuffix -opensuse_leap42.3, 17.09.1)
 	$(DOCKER) run --rm -v $(DIST_DIR)/amzn1:/dist:Z "nvidia/runtime/amzn:1-docker$*"
 
 %-opensuse_leap15.0:
-	runc="$(shell $(MAKE) -s $@-runc)" && \
+	runc="$(shell $(MAKE) --no-print-directory -s $@-runc)" && \
 	$(DOCKER) build --build-arg VERSION_ID="15.0" \
                         --build-arg RUNC_COMMIT="$${runc}" \
                         --build-arg PKG_VERS="$(VERSION)" \
@@ -141,7 +141,7 @@ opensuse_leap42.3: $(addsuffix -opensuse_leap42.3, 17.09.1)
 	$(DOCKER) run --rm -v $(DIST_DIR)/opensuse_leap15.0:/dist:Z "nvidia/runtime/opensuse/leap:15.0-docker$*"
 
 %-opensuse_leap42.3:
-	runc="$(shell $(MAKE) -s $@-runc)" && \
+	runc="$(shell $(MAKE) --no-print-directory -s $@-runc)" && \
 	$(DOCKER) build --build-arg VERSION_ID="42.3" \
                         --build-arg RUNC_COMMIT="$${runc}" \
                         --build-arg PKG_VERS="$(VERSION)" \


### PR DESCRIPTION
Based on comment from @torhans here:  https://github.com/NVIDIA/nvidia-docker/issues/657#issuecomment-413829563